### PR TITLE
Checks the return code of the common_options_handler. If it is truthy…

### DIFF
--- a/docopt_subcommands/subcommands.py
+++ b/docopt_subcommands/subcommands.py
@@ -92,7 +92,9 @@ class Subcommands:
                         options_first=True,
                         version=self.version)
 
-        self._common_option_handler(config)
+        common_option_code = self._common_option_handler(config)
+        if common_option_code:
+            return common_option_code
 
         command = config['<command>']
         if command is None:


### PR DESCRIPTION
… (i.e. not 0, EX_OK or None) command parsing stops and the return code is returned to the OS.