### PR TITLE
Removes leading text indents from docstrings before display.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,72 @@ build
 .csearchindex
 .hypothesis
 .idea
+
+# Created by https://www.gitignore.io/api/pycharm
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/dictionaries
+
+# Sensitive or high-churn files:
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.xml
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+
+# Gradle:
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-debug/
+
+# Mongo Explorer plugin:
+.idea/**/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Ruby plugin and RubyMine
+/.rakeTasks
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# *.iml
+# modules.xml
+# .idea/misc.xml
+# *.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+# End of https://www.gitignore.io/api/pycharm

--- a/docopt_subcommands/subcommands.py
+++ b/docopt_subcommands/subcommands.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from docopt import docopt
 
 DEFAULT_DOC_TEMPLATE = """{program}
@@ -12,6 +14,16 @@ Available commands:
 
 See '{program} help <command>' for help on specific commands.
 """
+
+
+def dedent(s):
+    """Removes the hanging dedent from all the first line of a string."""
+    head, _, tail = s.partition('\n')
+    dedented_tail = textwrap.dedent(tail)
+    result = "{head}\n{tail}".format(
+        head=head,
+        tail=dedented_tail)
+    return result
 
 
 def docstring_to_subcommand(docstring):
@@ -124,9 +136,10 @@ class Subcommands:
 
         # Parse the sub-command options
         config = docopt(
-            handler.__doc__.format(
-                program=self.program,
-                command=command),
+            dedent(
+                handler.__doc__.format(
+                    program=self.program,
+                    command=command)),
             argv,
             version=self.version)
 
@@ -148,8 +161,9 @@ class Subcommands:
             options = self._commands[command].__doc__
 
         return docopt(
-            options.format(
-                program=self.program,
-                command=command),
+            dedent(
+                options.format(
+                    program=self.program,
+                    command=command)),
             ['--help'],
             version=self.version)


### PR DESCRIPTION
Uses the Python Standard Library textwrap module to remove the leading indents from subcommand docstrings.

Regular docopt typically works with module docstrings, which are not indented. However, subcommand docstrings may be indented by some arbitrary amount. Currently docopt-subcommands does not remove this indent prior to display.